### PR TITLE
feat: add --yolo mode and billing: max config

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,8 @@ function addRunOptions(cmd: Command): Command {
     .option('--resume', 'Resume the most recent session', false)
     .option('-v, --verbose', 'Enable debug logging', false)
     .option('--approval-mode <mode>', 'Override approval mode (destructive, all, none)')
-    .option('--telegram', 'Start in Telegram bot mode', false);
+    .option('--telegram', 'Start in Telegram bot mode', false)
+    .option('--yolo', 'Full autonomous mode — no approvals, no permission prompts', false);
 }
 
 function toRunResult(cmd: Command): CliResult {
@@ -35,6 +36,7 @@ function toRunResult(cmd: Command): CliResult {
       verbose: opts.verbose as boolean,
       telegram: opts.telegram as boolean,
       approvalMode: opts.approvalMode as 'none' | 'destructive' | 'all' | undefined,
+      yolo: opts.yolo as boolean,
     },
   };
 }

--- a/src/core/__tests__/orchestrator.test.ts
+++ b/src/core/__tests__/orchestrator.test.ts
@@ -83,6 +83,7 @@ describe('Orchestrator', () => {
       },
       approvalMode: 'destructive',
       maxTotalBudgetUsd: 50.0,
+      billing: 'api',
     };
 
     mockCliOptions = {
@@ -93,6 +94,7 @@ describe('Orchestrator', () => {
       resume: false,
       verbose: false,
       telegram: false,
+      yolo: false,
     };
 
     mockSpawnAgent = vi.mocked(spawnAgent);

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -34,6 +34,7 @@ export interface SpawnOptions {
   maxTurns?: number;
   timeoutMs?: number;
   cwd?: string;
+  yolo?: boolean;
 }
 
 export interface AgentResponse {
@@ -155,6 +156,10 @@ export async function spawnAgent(
         args.push('--max-budget-usd', opts.maxBudgetUsd.toString());
       }
 
+      if (opts.yolo) {
+        args.push('--dangerously-skip-permissions');
+      }
+
       logger.debug('Spawning agent', { model: opts.model, maxTurns });
       const stdout = await runClaude(args, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS, opts.cwd);
       const output = parseOutput(stdout);
@@ -184,7 +189,7 @@ export async function spawnAgent(
 export async function resumeAgent(
   sessionId: string,
   prompt: string,
-  opts: { maxTurns?: number; timeoutMs?: number; cwd?: string; maxBudgetUsd?: number },
+  opts: { maxTurns?: number; timeoutMs?: number; cwd?: string; maxBudgetUsd?: number; yolo?: boolean },
 ): Promise<AgentResponse> {
   return withErrorBoundary(
     async () => {
@@ -199,6 +204,10 @@ export async function resumeAgent(
 
       if (opts.maxBudgetUsd != null && opts.maxBudgetUsd > 0) {
         args.push('--max-budget-usd', String(opts.maxBudgetUsd));
+      }
+
+      if (opts.yolo) {
+        args.push('--dangerously-skip-permissions');
       }
 
       logger.debug('Resuming agent', { sessionId: sessionId.slice(0, 8), maxTurns });

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,12 @@ async function runOrchestrator(opts: CliResult & { command: 'run' }): Promise<vo
     (config as { approvalMode: string }).approvalMode = cliOpts.approvalMode;
   }
 
+  // YOLO mode — override approval mode and warn
+  if (cliOpts.yolo) {
+    (config as { approvalMode: string }).approvalMode = 'none';
+    logger.warn('YOLO mode — all actions auto-approved, agents run with full permissions');
+  }
+
   // Resume or create new
   let state;
   if (cliOpts.resume) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,6 +56,7 @@ export const EchelonConfigSchema = z.object({
   approvalMode: z.enum(['destructive', 'all', 'none']).default('destructive'),
   maxTotalBudgetUsd: z.number().positive().default(50.0),
   telegram: TelegramConfigSchema.optional(),
+  billing: z.enum(['api', 'max']).default('api'),
 });
 
 export type EchelonConfig = z.infer<typeof EchelonConfigSchema>;
@@ -233,6 +234,7 @@ export interface CliOptions {
   verbose: boolean;
   telegram: boolean;
   approvalMode?: EchelonConfig['approvalMode'];
+  yolo: boolean;
 }
 
 // --- Events ---

--- a/src/telegram/tool-handlers.ts
+++ b/src/telegram/tool-handlers.ts
@@ -35,6 +35,7 @@ function getOrchestrator(config: EchelonConfig): Orchestrator {
       resume: !!state,
       verbose: false,
       telegram: true,
+      yolo: false,
     },
     state: state ?? undefined,
   });


### PR DESCRIPTION
## Summary
- **`--yolo` flag**: Full autonomous mode — sets `approvalMode: none` and passes `--dangerously-skip-permissions` to all Claude agents. No human-in-the-loop, no permission prompts.
- **`billing: 'max'` config**: When set, disables all budget gating (layer + total) since costs aren't real on Max plans. Dry-run shows "∞ (Max plan)" instead of dollar amounts. Cascade complete logs label costs as "estimated".

## Changes
| File | Change |
|------|--------|
| `src/lib/types.ts` | Add `billing` to config schema, `yolo` to CliOptions |
| `src/cli.ts` | Add `--yolo` CLI option |
| `src/index.ts` | Override approvalMode + warn when yolo |
| `src/core/agent.ts` | Pass `--dangerously-skip-permissions` when yolo |
| `src/core/orchestrator.ts` | Skip budget checks when billing=max, thread yolo to agents |
| `src/telegram/tool-handlers.ts` | Add yolo: false default |
| Tests | Add billing + yolo fields to mocks |

## Test plan
- [x] `npm test` — 106/106 passing
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)