### PR TITLE
fix: comprehensive hardening — 25 bugs across 13 files

### DIFF
--- a/src/cheenoski/scheduler.ts
+++ b/src/cheenoski/scheduler.ts
@@ -386,6 +386,7 @@ export class Scheduler {
                 slot.branchName,
                 this.config.project.baseBranch,
                 slot.issueNumber,
+                slot.worktreePath ?? undefined,
               );
             } finally {
               this.mergeMutex.release();

--- a/src/core/__tests__/orchestrator.test.ts
+++ b/src/core/__tests__/orchestrator.test.ts
@@ -22,20 +22,30 @@ vi.mock('../state.js', async () => {
 });
 
 vi.mock('../../lib/logger.js', () => {
-  const createMockLogger = () => ({
+  const mockLogger: any = {
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
     debug: vi.fn(),
     errorWithType: vi.fn(),
-    child: vi.fn(function(this: any) { return createMockLogger(); }),
-  });
+    setLevel: vi.fn(),
+    setQuiet: vi.fn(),
+    child: vi.fn(),
+  };
+  // child() returns the SAME mock instance so all calls are captured
+  mockLogger.child.mockReturnValue(mockLogger);
 
   return {
-    logger: createMockLogger(),
+    logger: mockLogger,
     generateCorrelationId: vi.fn(() => 'mock-correlation-id'),
   };
 });
+
+vi.mock('../../lib/github-client.js', () => ({
+  githubClient: {
+    exec: vi.fn().mockResolvedValue({ stdout: '[]', stderr: '' }),
+  },
+}));
 
 vi.mock('../../lib/transcript.js', () => ({
   TranscriptWriter: class MockTranscriptWriter {

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -113,7 +113,8 @@ export function loadState(sessionId: string): EchelonState | null {
 export function findLatestSession(repo: string): string | null {
   if (!existsSync(SESSIONS_DIR)) return null;
 
-  const prefix = repo.replace('/', '-');
+  // Must match the same sanitization as createState uses for sessionId generation
+  const prefix = repo.replace(/[^a-zA-Z0-9-]/g, '-');
   const dirs = readdirSync(SESSIONS_DIR)
     .filter(d => d.startsWith(prefix))
     .sort()

--- a/src/lib/git-detect.ts
+++ b/src/lib/git-detect.ts
@@ -21,10 +21,43 @@ export function detectGitRepo(): GitRepoInfo | null {
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
 
-    const baseBranch = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    // Detect the default branch (main/master), NOT the current branch.
+    // symbolic-ref HEAD returns the CURRENT branch, which is wrong for baseBranch.
+    let baseBranch = 'main'; // sensible default
+    try {
+      // Try refs/remotes/origin/HEAD which points to the default branch
+      const defaultRef = execFileSync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      // refs/remotes/origin/HEAD -> refs/remotes/origin/main
+      baseBranch = defaultRef.replace('refs/remotes/origin/', '');
+    } catch {
+      // origin/HEAD not set — try common default branch names
+      try {
+        execFileSync('git', ['rev-parse', '--verify', 'refs/heads/main'], {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        baseBranch = 'main';
+      } catch {
+        try {
+          execFileSync('git', ['rev-parse', '--verify', 'refs/heads/master'], {
+            encoding: 'utf-8',
+            stdio: ['pipe', 'pipe', 'pipe'],
+          });
+          baseBranch = 'master';
+        } catch {
+          // Fall back to current branch as last resort
+          baseBranch = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {
+            encoding: 'utf-8',
+            stdio: ['pipe', 'pipe', 'pipe'],
+          }).trim();
+        }
+      }
+    }
+
+    if (!repo) return null;
 
     return { repo, path, baseBranch };
   } catch {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -30,6 +30,10 @@ export function buildSystemPrompt(
         'IMPORTANT: Be decisive. Make prioritization decisions yourself — do NOT ask questions.',
         'Your output is passed directly to the Eng Lead, so be thorough and specific.',
         'Always emit an update_plan action block.',
+        '',
+        'CRITICAL: You are a PLANNING layer. Do NOT write code, create files, or modify the codebase.',
+        'Do NOT use tools to edit files or run commands. Your ONLY output is natural language + action blocks.',
+        'Code implementation is handled exclusively by downstream engineers (Cheenoski).',
       ].join('\n');
 
     case 'eng-lead':
@@ -68,6 +72,10 @@ export function buildSystemPrompt(
         'The Team Lead will convert these directly into create_issues action blocks.',
         'Be COMPLETE — include file paths, function signatures, and implementation details.',
         'Make reasonable technical decisions yourself rather than deferring.',
+        '',
+        'CRITICAL: You are a PLANNING layer. Do NOT write code, create files, or modify the codebase.',
+        'Do NOT use tools to edit files or run commands. Your ONLY output is natural language + action blocks.',
+        'Code implementation is handled exclusively by downstream engineers (Cheenoski).',
       ].join('\n');
 
     case 'team-lead':
@@ -79,7 +87,7 @@ export function buildSystemPrompt(
         '',
         'Available actions:',
         '',
-        '### create_issues (REQUIRED — do this FIRST)',
+        '### create_issues (do this FIRST if new issues are needed)',
         '```json',
         '{"action": "create_issues", "issues": [',
         '  {"title": "[Tests] Add unit tests for orchestrator", "body": "## Overview\\n...\\n## Requirements\\n- [ ] ...\\n## Technical Notes\\n...\\n## Acceptance Criteria\\n- ...", "labels": ["testing", "cheenoski-0"]},',
@@ -94,12 +102,15 @@ export function buildSystemPrompt(
         '',
         'WORKFLOW:',
         '1. Read the Eng Lead\'s task specifications',
-        '2. Emit ONE create_issues action with ALL issues in a single array',
-        '3. Emit ONE invoke_cheenoski action for the highest-priority batch (cheenoski-0)',
+        '2. Check the "Existing Open Issues" section (if present) for already-created issues',
+        '3. Only create_issues for tasks NOT already covered by existing open issues',
+        '4. Emit ONE invoke_cheenoski action for the highest-priority batch',
         '',
         'RULES:',
-        '- ALWAYS create issues BEFORE invoking cheenoski',
-        '- Put ALL issues in a SINGLE create_issues action block',
+        '- If existing issues already cover the work, skip create_issues and go straight to invoke_cheenoski',
+        '- If new issues are needed, create them BEFORE invoking cheenoski',
+        '- Put ALL new issues in a SINGLE create_issues action block',
+        '- Do NOT create duplicate issues — check the existing issues list first',
         '- Issue bodies must be detailed enough to serve as prompts for AI engineers',
         '- Do NOT ask questions. Do NOT use request_info. Just create the issues.',
         '- If something is ambiguous, make a reasonable decision.',


### PR DESCRIPTION
## Summary

Systematic audit found ~100 bugs across the codebase. This PR fixes the 25 most critical and high-severity ones across 13 files.

### Critical Fixes
- **merge.ts**: Rebase was running in main repo instead of worktree, corrupting working tree state. Conflict files were always empty (captured after abort). Stash restore used fragile index refs.
- **bot.ts**: Empty `chatId` env var silently produced a non-functional bot instead of throwing.

### High-Severity Fixes
- **orchestrator.ts**: Management layers (2IC, Eng Lead, Team Lead) were receiving `--dangerously-skip-permissions` in yolo mode, allowing them to write code directly and bypass the entire hierarchy. Now only Cheenoski engineers get yolo access.
- **orchestrator.ts**: `buildDownwardPrompt` now async — injects existing open issues for Team Lead to prevent duplicates. `shutdown()` no longer calls `process.exit(0)` (was preventing `finally` blocks). Status properly distinguishes 'paused' (user shutdown) vs 'failed' (budget/error).
- **error-boundaries.ts**: Circuit breaker didn't re-open on half-open probe failure. Error classification patterns were overly broad ("exit" matched non-crash errors).
- **state.ts**: `findLatestSession` prefix didn't match `createState`'s sanitization, breaking session resume for repos with dots/underscores.
- **git-detect.ts**: Returned current branch instead of default branch (main/master).
- **index.ts**: SIGINT/SIGTERM handlers didn't call `process.exit()`, leaving process hanging.
- **bot.ts**: Auth bypass when `fromUserId` was undefined. `allowedUserIds` env parsing short-circuited.
- **handler.ts**: `trimHistory` could produce orphaned `tool_result` messages violating API sequence requirements.
- **prompts.ts**: 2IC and Eng Lead now explicitly prohibited from writing code. Team Lead prompt is conditional on existing issues.
- **github-issues.ts**: Issue dedup — fetches existing titles before creating, prevents intra-batch duplicates too.
- **agent.ts**: Timeout/close/error race condition fixed with `settled` guard.

### Medium Fixes
- **merge.ts**: `hasChanges` uses three-dot diff for accurate worktree comparison.
- **scheduler.ts**: Passes worktree path to `mergeBranch` for correct rebase target.
- **orchestrator.test.ts**: Mock logger uses shared instance so budget/warn assertions work.

## Test plan
- [x] All 68 existing tests pass
- [x] TypeScript compiles clean
- [x] Build succeeds
- [ ] Manual: Run echelon cascade in yolo mode — verify management layers don't write code
- [ ] Manual: Run cheenoski with parallel merges — verify no main repo corruption
- [ ] Manual: Start telegram bot without ECHELON_TELEGRAM_CHAT_ID — verify clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)