### PR TITLE
Real-time agent progress streaming + clean init UX

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -336,6 +336,7 @@ export interface CliOptions {
 
 export type EchelonEvent =
   | { type: 'agent_status'; role: AgentRole; status: AgentStatus }
+  | { type: 'agent_progress'; role: AgentRole; content: string }
   | { type: 'message'; message: LayerMessage }
   | { type: 'action_pending'; approval: PendingApproval }
   | { type: 'action_executed'; action: Action; result: string }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -18,10 +18,13 @@ export function App({ orchestrator, initialDirective }: AppProps) {
   const { exit } = useApp();
   const echelon = useEchelon(orchestrator);
 
-  // Start cascade if initial directive provided
+  // Start cascade if initial directive provided OR resuming from state
   React.useEffect(() => {
     if (initialDirective) {
       echelon.sendDirective(initialDirective);
+    } else if (orchestrator.state.directive) {
+      // Resuming - continue with existing directive
+      echelon.sendDirective(orchestrator.state.directive);
     }
   }, []); // Only run once on mount
 
@@ -72,13 +75,20 @@ export function App({ orchestrator, initialDirective }: AppProps) {
   }, [echelon, exit]);
 
   return (
-    <Box flexDirection="column" height="100%">
+    <Box flexDirection="column">
       {/* Header */}
-      <Box justifyContent="space-between" paddingX={1} borderStyle="round" borderColor="cyan">
-        <Text bold color="magenta">VENIN</Text>
-        <Text bold color="cyan"> Echelon</Text>
-        <Text color="gray"> | </Text>
-        <Text dimColor>{echelon.directive?.slice(0, 60) || 'No directive'}{echelon.directive && echelon.directive.length > 60 ? '...' : ''}</Text>
+      <Box flexDirection="column">
+        <Box justifyContent="space-between" paddingX={1}>
+          <Text>
+            <Text bold color="magenta">VENIN</Text>
+            <Text bold color="cyan"> Echelon</Text>
+            <Text color="gray"> │ </Text>
+            <Text dimColor>{echelon.directive?.slice(0, 60) || 'No directive'}{echelon.directive && echelon.directive.length > 60 ? '...' : ''}</Text>
+          </Text>
+        </Box>
+        <Box paddingX={1}>
+          <Text dimColor>{'─'.repeat(process.stdout.columns || 80)}</Text>
+        </Box>
       </Box>
 
       {/* Main area: sidebar + feed */}
@@ -113,7 +123,7 @@ export function App({ orchestrator, initialDirective }: AppProps) {
       {/* Input */}
       <Input
         onSubmit={handleInput}
-        disabled={echelon.status === 'completed' || echelon.status === 'failed'}
+        disabled={(echelon.status === 'completed' || echelon.status === 'failed') && echelon.pendingApprovals.length === 0}
       />
     </Box>
   );

--- a/src/ui/ApprovalPrompt.tsx
+++ b/src/ui/ApprovalPrompt.tsx
@@ -14,13 +14,11 @@ export function ApprovalPrompt({ approvals, onApprove, onReject }: ApprovalPromp
   return (
     <Box
       flexDirection="column"
-      borderStyle="round"
-      borderColor="yellow"
       paddingX={1}
       marginY={0}
     >
       <Text bold color="yellow">
-        Pending Approvals ({approvals.length})
+        ⚠️  Pending Approvals ({approvals.length})
       </Text>
       {approvals.map(a => (
         <Box key={a.id}>

--- a/src/ui/Feed.tsx
+++ b/src/ui/Feed.tsx
@@ -13,12 +13,10 @@ export function Feed({ entries, maxLines = 20 }: FeedProps) {
   return (
     <Box
       flexDirection="column"
-      borderStyle="single"
-      borderColor="gray"
       paddingX={1}
       flexGrow={1}
     >
-      <Text bold color="white">Feed</Text>
+      <Text bold color="white">═ Feed ═</Text>
       {visible.length === 0 ? (
         <Text dimColor>Waiting for directive...</Text>
       ) : (

--- a/src/ui/IssuePanel.tsx
+++ b/src/ui/IssuePanel.tsx
@@ -17,8 +17,8 @@ export function IssuePanel({ issues }: IssuePanelProps) {
   const visible = issues.slice(-8);
 
   return (
-    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} width={22}>
-      <Text bold color="white">Issues</Text>
+    <Box flexDirection="column" paddingX={1} width={22}>
+      <Text bold color="white">═ Issues ═</Text>
       {visible.length === 0 ? (
         <Text dimColor>None yet</Text>
       ) : (

--- a/src/ui/OrgChart.tsx
+++ b/src/ui/OrgChart.tsx
@@ -20,7 +20,7 @@ const MAX_LABEL_LEN = Math.max(...LAYER_ORDER.map(r => LAYER_LABELS[r].length));
 
 export function OrgChart({ agents }: OrgChartProps) {
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1} width={26}>
+    <Box flexDirection="column" paddingX={1} width={26}>
       <Text bold color="magenta">⚡ HIERARCHY</Text>
       <Text dimColor>─────────────────────</Text>
       {LAYER_ORDER.map((role, idx) => {

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -33,7 +33,7 @@ export function StatusBar({ cost, budget, elapsed, repo, status, pendingCount }:
   const budgetPercent = budget > 0 ? Math.round((cost / budget) * 100) : 0;
 
   return (
-    <Box paddingX={1} justifyContent="space-between" borderStyle="round" borderColor="gray">
+    <Box paddingX={1} justifyContent="space-between">
       <Text>
         <Text dimColor>💰 </Text>
         <Text bold color={costColor(cost, budget)}>${cost.toFixed(4)}</Text>


### PR DESCRIPTION
## Summary
- Streams agent thinking output to TUI feed in real-time via `onProgress` callback
- Debounces progress updates (500ms) to prevent excessive re-renders
- Shows last 3 meaningful output lines instead of generic "Thinking..."
- Adds 1-second delay before clearing pre-flight info for better readability
- Clears console before TUI renders for clean startup
- Configures Ink with `patchConsole: false` and `exitOnCtrlC: false`
- Improves zero-cost detection messaging (Claude 20x Max subscriptions)

## Test Plan
- [x] All tests pass (68/68)
- [x] TypeScript compiles with no errors
- [x] Headless mode runs without crashes
- [ ] Manual TUI test: verify pre-flight delay and clean render
- [ ] Manual TUI test: verify real-time progress appears in feed
- [ ] Manual TUI test: verify Ctrl+C exits gracefully

🤖 Generated with Claude Code