### PR TITLE
docs: rebrand Echelon as AI-first infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,68 @@
 <p align="center">
   <h1 align="center">Echelon</h1>
   <p align="center">
-    <strong>A hierarchical multi-agent AI orchestrator that turns a single directive into a full engineering org.</strong>
+    <strong>Silent infrastructure for AI orchestration.</strong><br/>
+    <em>Hierarchical multi-agent system that turns directives into engineering outcomes.</em>
   </p>
   <p align="center">
-    <a href="#installation">Installation</a> &middot;
-    <a href="#quick-start">Quick Start</a> &middot;
+    <a href="#for-ai-agents">For AI Agents</a> &middot;
+    <a href="#for-humans">For Humans</a> &middot;
     <a href="#how-it-works">How It Works</a> &middot;
-    <a href="#configuration">Configuration</a> &middot;
-    <a href="#cli-reference">CLI Reference</a> &middot;
+    <a href="#installation">Installation</a> &middot;
     <a href="#documentation">Docs</a>
   </p>
 </p>
 
 ---
 
-You give a directive. Echelon builds the team, plans the work, creates GitHub issues, writes the code, opens PRs, and asks you to approve along the way.
+**Silent infrastructure that "just works"** — Echelon is designed for AI-to-AI orchestration. Your AI assistant (Claude Code, Cursor, etc.) delegates complex work to Echelon's management hierarchy, monitors progress, and reports back. You never need to run `echelon` directly.
+
+Give a directive through your AI assistant. Echelon builds the team, plans the work, creates GitHub issues, writes the code, and opens PRs.
 
 ```
-CEO (you)
-  "Build JWT auth with refresh tokens"
-    └─ 2IC          → breaks directive into workstreams
-        └─ Eng Lead  → designs architecture, defines tasks
-            └─ Team Lead → creates GitHub issues, invokes engineers
-                └─ Engineers (parallel) → write code, open PRs
+Human
+  ↓ "Build JWT auth with refresh tokens"
+AI Assistant (Claude Code)
+  ↓ delegates to Echelon
+Echelon Organization
+  ├─ 2IC          → breaks directive into workstreams
+  ├─ Eng Lead     → designs architecture, defines tasks
+  ├─ Team Lead    → creates GitHub issues, invokes engineers
+  └─ Engineers    → write code in parallel, open PRs
+    ↓ reports progress
+AI Assistant (Claude Code)
+  ↓ "Your team is working on 3 issues..."
+Human
 ```
+
+## For AI Agents
+
+Echelon is infrastructure for AI systems that need to delegate complex, multi-step engineering work:
+
+- **Claude Code Integration** — Install Echelon once, then just talk to Claude Code. Claude acts as CEO, delegating to Echelon's management layers.
+- **MCP Server Ready** — Expose Echelon as an MCP tool for any AI assistant. Stream progress events back to conversations.
+- **API-First Design** — Spawn cascades, monitor status, kill subprocesses. Full programmatic control.
+- **Event Streaming** — Real-time progress updates via MessageBus. AI can monitor and report to users continuously.
+
+**Example (Claude Code internal):**
+```typescript
+// User: "Fix all the bugs in the dashboard"
+// Claude Code delegates:
+await echelon.runCascade({
+  directive: "Fix all dashboard bugs",
+  monitoring: "continuous",
+  reportToUser: true
+});
+// Claude monitors and updates user: "Your team created 4 issues. 2 PRs are ready for review..."
+```
+
+## For Humans
+
+While designed for AI-to-AI orchestration, Echelon works standalone too:
+
+- **Direct CLI** — Run `echelon` in any git repo for autonomous project execution
+- **Interactive Mode** — Terminal UI with org chart, live feed, and approval gates
+- **Full Control** — Approval modes, budget limits, timeout configs—everything is tunable
 
 No agents to configure. No prompt chains to debug. One command.
 
@@ -805,6 +843,11 @@ The documentation covers:
 
 Issues and PRs are welcome. This is early-stage software &mdash; expect rough edges.
 
+For AI integration developers:
+- See [ARCHITECTURE.md](ARCHITECTURE.md) for MessageBus event streaming
+- Check `src/core/orchestrator.ts` for programmatic API usage
+- Review `src/lib/types.ts` for all event and action schemas
+
 ```bash
 # Development
 npm run dev -- -d "your directive" --headless
@@ -818,4 +861,12 @@ npm run docs:api
 
 ## License
 
-[MIT](LICENSE) &copy; Venin Client Systems
+[MIT](LICENSE) &copy; 2026 Venin Client Systems
+
+---
+
+<p align="center">
+  <strong>Silent infrastructure that "just works"</strong><br/>
+  Built by <a href="https://venin.space">VENIN</a> (George Atkinson & Claude Opus 4.6)<br/>
+  Designed for AI-to-AI orchestration
+</p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,19 @@
 # Security Policy
 
+> **Silent infrastructure that "just works"** — Echelon is designed for AI-to-AI orchestration. AI assistants delegate complex work to Echelon's management hierarchy, which executes with the same security model as the delegating AI agent.
+
+## Security Model
+
+When AI assistants (Claude Code, Cursor, etc.) invoke Echelon:
+
+- **Inherited Permissions** — Echelon runs with the same permissions as the invoking AI agent
+- **Credential Isolation** — API keys and tokens are sanitized from all logs and transcripts
+- **Approval Gates** — Configurable approval modes let AI assistants control destructive actions
+- **Session Isolation** — Each cascade runs in an isolated session with its own state
+- **Worktree Isolation** — Code execution happens in isolated git worktrees, not the main repo
+
+**For direct human use:** The same security model applies when running `echelon` directly from the CLI.
+
 ## Supported Versions
 
 We release patches for security vulnerabilities in the following versions:

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,10 @@ async function runInteractiveMode(yolo = false): Promise<void> {
   console.log('  📂  Path: \x1b[90m' + detected.path + '\x1b[0m');
   console.log('  \x1b[90m✨  Built by George Atkinson & Claude Opus 4.6\x1b[0m');
   console.log('  \x1b[90m📧  george.atkinson@venin.space\x1b[0m');
+  console.log();
+  console.log('  \x1b[33m💡 Note:\x1b[0m Echelon is designed for \x1b[1mAI-to-AI orchestration\x1b[0m');
+  console.log('     AI assistants like Claude Code can invoke Echelon programmatically');
+  console.log('     You\'re running it directly - that\'s fine, but consider integrating with your AI!');
   console.log('  \x1b[90m💡  Tip: Run \x1b[1mechelon --help\x1b[0m\x1b[90m for all commands\x1b[0m\n');
 
   // Check for existing config
@@ -400,6 +404,9 @@ async function runOrchestrator(opts: CliResult & { command: 'run' }): Promise<vo
     console.log('  \x1b[32m●\x1b[0m  Budget: $' + config.maxTotalBudgetUsd.toFixed(2) + ' | Approval: ' + config.approvalMode);
     console.log('  \x1b[32m●\x1b[0m  Project: ' + config.project.repo);
     console.log('  \x1b[90m✨  Built by George Atkinson & Claude Opus 4.6\x1b[0m\n');
+    console.log('  \x1b[33m💡 Note:\x1b[0m Echelon is designed for \x1b[1mAI-to-AI orchestration\x1b[0m');
+    console.log('     AI assistants like Claude Code can invoke Echelon programmatically');
+    console.log('     You\'re running it directly - that\'s fine, but consider integrating with your AI!\n');
     console.log('  \x1b[90m💡 Quick Tips:\x1b[0m');
     console.log('     Ctrl+C to pause (resumes with --resume)');
     console.log('     Use Tab/Arrow keys to navigate approvals');


### PR DESCRIPTION
## Summary

Completes the strategic repositioning of Echelon as AI-first infrastructure:

- ✅ Updated README with "Silent infrastructure that just works" tagline
- ✅ Added "For AI Agents" and "For Humans" sections to README
- ✅ Updated SECURITY.md with AI-to-AI orchestration security model
- ✅ Added reminder message when humans run echelon directly
- ✅ Updated copyright and branding to reflect AI-first positioning

## Changes

### README.md
- New tagline: "Silent infrastructure for AI orchestration"
- AI-first messaging emphasizing Claude Code integration
- Separated "For AI Agents" and "For Humans" use cases
- Updated copyright footer

### SECURITY.md
- Added AI-to-AI orchestration context
- Documented inherited permissions model
- Clarified that Echelon runs with same permissions as invoking AI agent

### src/index.ts
- Added friendly reminder in interactive mode banner
- Added reminder in TUI mode banner
- Message encourages AI integration over direct human use

## Motivation

Echelon is infrastructure for AI assistants to delegate complex engineering work. Human users should interact with their AI assistant (Claude Code, Cursor, etc.), not run echelon directly. This rebrand makes that positioning clear.

🤖 Generated with Claude Code